### PR TITLE
Fix warnings, add backup to control node option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -44,6 +44,16 @@ The upgrade follows the [official Mattermost upgrade guide](https://docs.matterm
 This means that you must ensure that the simple upgrade procedure is adequate for the upgrade you want to perform.
 Technically, you can also downgrade the Mattermost server by specifying a lower version number.
 
+#### Setup
+
+- For host setup, see below
+- Clone this repository or make sure you have the files `mattermost-update.yml` and `vars/mattermost.yml` locally
+- Configure the variables according to your needs in `vars/mattermost.yml`. The top block is for the Mattermost server, the bottom block for the local / control machine.
+  - `tmp_path`: Temporary path on the server to download the new Mattermost version to
+  - `install_path`: Path where you `mattermost` folder is located
+  - `backup_path`: Path where you want to store the backup of the old Mattermost version on the server
+  - `do_cntrl_backup`: Boolean to decide if you want to copy the backup to the control machine or not
+  - `cntrl_backup_path`: Path where you want to store the backup of the old Mattermost version on the control machine
 
 
 ## Host setup

--- a/Readme.md
+++ b/Readme.md
@@ -8,6 +8,7 @@ My ansible workflows are here to:
 The latter workflow is adopted from online workflows.
 Check out the vars folder for settings on which keys to copy!
 
+
 ## Playbooks
 
 Run the playbooks via:
@@ -15,6 +16,35 @@ Run the playbooks via:
 ```
 ansible-playbook PLAYBOOK-NAME.yml
 ```
+
+### Update existing computers
+
+The playbook `update_apt.yml` updates the apt cache and upgrades all packages.
+It is run via:
+
+```
+ansible-playbook update_apt.yml
+```
+
+### Update Mattermost
+
+The playbook `mattermost_update.yml` updates the version of the Mattermost server.
+It is run via:
+
+```
+ansible-playbook mattermost_update.yml
+```
+
+The playbook first asks which Mattermost version to download and install.
+Make sure that you give the three digit version number, e.g. `5.32.1`, that you want to upgrade to.
+The playbook then downloads the new version, stops the Mattermost server, and installs the new version.
+The upgrade follows the [official Mattermost upgrade guide](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html).
+
+**Warning**: Special instructions are not taken into consideration.
+This means that you must ensure that the simple upgrade procedure is adequate for the upgrade you want to perform.
+Technically, you can also downgrade the Mattermost server by specifying a lower version number.
+
+
 
 ## Host setup
 
@@ -35,6 +65,7 @@ mattermost-droplet-do ansible_host=159.223.133.198
 [all:vars]
 ansible_python_interpreter=/usr/bin/python3
 ```
+
 
 ## Help
 

--- a/mattermost-update.yml
+++ b/mattermost-update.yml
@@ -11,12 +11,19 @@
       private: no
   vars_files:
     - vars/mattermost-update-vars.yml
+  vars:
+    - backup_archive: "mattermost-backup-{{ansible_date_time.iso8601}}.tar.gz"
 
   tasks:
-    - name: Clear extract folder
-      ansible.builtin.command:
-        chdir: "{{ tmp_path }}"
-        cmd: "rm -rf mattermost*tar.gz mattermost-upgrade"
+    - name: Delete temporary folder
+      ansible.builtin.file:
+        path: "{{ tmp_path }}"
+        state: absent
+
+    - name: Create temporary folder
+      ansible.builtin.file:
+        path: "{{ tmp_path }}"
+        state: directory
 
     - name: Download new version
       get_url:
@@ -38,12 +45,18 @@
         state: stopped
       become: yes
 
-    - name: Backup existing installation
-      ansible.builtin.copy:
-        src: "{{ install_path }}/mattermost"
-        dest: "{{ backup_path }}/mattermost-back-{{ansible_date_time.iso8601}}"
-        remote_src: yes
+    - name: Backup existing installation as tar.gz
+      community.general.archive:
+        path: "{{ install_path }}/mattermost"
+        dest: "{{ backup_path }}/{{ backup_archive}}"
+        format: gz
       become: yes
+
+    - name: Copy backup to control node
+      ansible.builtin.fetch:
+        src: "{{ backup_path }}/{{ backup_archive }}"
+        dest: "{{ cntrl_backup_path }}"
+      when: do_cntrl_backup
 
     - name: Prune installation files
       ansible.builtin.shell:
@@ -56,9 +69,12 @@
         cmd: sudo cp -an {{ tmp_path }}/mattermost-upgrade/. mattermost/
 
     - name: Change ownership of files
-      ansible.builtin.command:
-        chdir: "{{ install_path }}"
-        cmd: chown -R mattermost:mattermost mattermost
+      ansible.builtin.file:
+        path: "{{ install_path }}/mattermost"
+        state: directory
+        recurse: yes
+        owner: mattermost
+        group: mattermost
       become: yes
 
     - name: Start the mattermost server

--- a/vars/mattermost-update-vars.yml
+++ b/vars/mattermost-update-vars.yml
@@ -7,3 +7,4 @@ backup_path: "/home/reto/backups"
 # variables on control node
 do_cntrl_backup: true  # activate a local backup to the control node
 cntrl_backup_path: "/home/reto/mm_backups"
+

--- a/vars/mattermost-update-vars.yml
+++ b/vars/mattermost-update-vars.yml
@@ -1,4 +1,9 @@
 ---
+# variables on target machines
 tmp_path: "/home/reto/tmp"
 install_path: "/opt"
 backup_path: "/home/reto/backups"
+
+# variables on control node
+do_cntrl_backup: true  # activate a local backup to the control node
+cntrl_backup_path: "/home/reto/mm_backups"


### PR DESCRIPTION
Fix warnings in issue #1.

This also adds some updated and new features.
- Backups are not archived as `tar.gz` archives.
- If wanted (and set in the `vars/mattermost-update-vars.yml` accordingly, a backup to the control node is now performed. This means that the `tar.gz` folder is backed up appropriately.

**Note**: The MySQL database is not backed up, only the installation folder.

Closes #1  